### PR TITLE
Add English docs, handle data URL parsing edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1 align="center">Simple mind map</h1>
 
+[English README](./README_EN.md)
+
 [![npm-version](https://img.shields.io/npm/v/simple-mind-map)](https://www.npmjs.com/package/simple-mind-map)
 ![npm download](https://img.shields.io/npm/dm/simple-mind-map)
 [![GitHub issues](https://img.shields.io/github/issues/wanglin2/mind-map)](https://github.com/wanglin2/mind-map/issues)

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,45 @@
+# Simple Mind Map
+
+This repository contains a JavaScript mind map library and a web application built with it.
+
+## Features
+- Plugin based architecture to keep the core lightweight.
+- Supports multiple structures such as logic diagrams, organizational charts and fishbone diagrams.
+- Highly customizable themes and styles.
+- Node content can be text (plain or rich), images, icons, links, notes, tags, summaries and formulas.
+- Dragging, free layout and different node shapes.
+- Canvas zooming and panning.
+- Export to `json`, `png`, `svg`, `pdf`, `markdown`, `xmind` and `txt` and import from `json`, `xmind` and `markdown`.
+- Shortcuts, undo/redo, associative lines, search and replace, mini map, watermarks, scrollbars and more.
+
+## Installation
+```bash
+npm i simple-mind-map
+```
+
+## Usage
+Create a container element with a non zero width and height and then instantiate:
+```html
+<div id="mindMapContainer"></div>
+```
+```js
+import MindMap from 'simple-mind-map'
+
+const mindMap = new MindMap({
+  el: document.getElementById('mindMapContainer'),
+  data: {
+    data: { text: 'Root' },
+    children: []
+  }
+})
+```
+For more features see the [documentation](https://wanglin2.github.io/mind-map-docs/).
+
+## Updating translations
+When adding new UI strings please update `web/src/lang/en_us.js` with an English translation and keep the key structure in sync with `zh_cn.js` and `zh_tw.js`.
+
+## Running tests
+Tests are located in `simple-mind-map/test`. Run them with:
+```bash
+npm run test --prefix simple-mind-map
+```

--- a/simple-mind-map/README.md
+++ b/simple-mind-map/README.md
@@ -1,3 +1,5 @@
 # 一个web思维导图的简单实现
 
+[English README](./README_EN.md)
+
 详细文档见：[https://github.com/wanglin2/mind-map](https://github.com/wanglin2/mind-map)

--- a/simple-mind-map/README_EN.md
+++ b/simple-mind-map/README_EN.md
@@ -1,0 +1,3 @@
+# A Simple Web Mind Map
+
+For detailed documentation please visit [https://github.com/wanglin2/mind-map](https://github.com/wanglin2/mind-map).

--- a/simple-mind-map/package.json
+++ b/simple-mind-map/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint src/",
     "format": "prettier --write .",
     "types": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types --target es2017 --skipLibCheck & node ./bin/createPluginsTypeFiles.js",
-    "wsServe": "node ./bin/wsServer.mjs"
+    "wsServe": "node ./bin/wsServer.mjs",
+    "test": "node ./test/utils.test.js"
   },
   "module": "index.js",
   "main": "./dist/simpleMindMap.umd.min.js",

--- a/simple-mind-map/src/utils/index.js
+++ b/simple-mind-map/src/utils/index.js
@@ -139,7 +139,7 @@ export const resizeImg = (imgUrl, maxWidth, maxHeight) => {
   })
 }
 
-//  从头html结构字符串里获取带换行符的字符串
+//  从html结构字符串里获取带换行符的字符串
 export const getStrWithBrFromHtml = str => {
   str = str.replace(/<br>/gim, '\n')
   let el = document.createElement('div')
@@ -248,6 +248,9 @@ export const parseDataUrl = data => {
   if (!/^data:/.test(data)) return data
   let [typeStr, base64] = data.split(',')
   let res = /^data:[^/]+\/([^;]+);/.exec(typeStr)
+  if (!res) {
+    return null
+  }
   let type = res[1]
   return {
     type,

--- a/simple-mind-map/src/utils/simulateCSSBackgroundInCanvas.js
+++ b/simple-mind-map/src/utils/simulateCSSBackgroundInCanvas.js
@@ -15,13 +15,13 @@ const getNumberValueFromStr = value => {
 
 // 缩放宽度
 const zoomWidth = (ratio, height) => {
-  // w / height = ratio
+  // width / height = ratio
   return ratio * height
 }
 
 // 缩放高度
 const zoomHeight = (ratio, width) => {
-  // width / h = ratio
+  // width / height = ratio
   return width / ratio
 }
 

--- a/simple-mind-map/test/utils.test.js
+++ b/simple-mind-map/test/utils.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { parseDataUrl } = require('../src/utils/index.js');
+
+describe('parseDataUrl', () => {
+  it('parses valid data url', () => {
+    const input = 'data:image/png;base64,abcd';
+    const res = parseDataUrl(input);
+    assert.deepStrictEqual(res, { type: 'png', base64: 'abcd' });
+  });
+
+  it('returns original string when not a data url', () => {
+    const input = 'hello';
+    const res = parseDataUrl(input);
+    assert.strictEqual(res, 'hello');
+  });
+
+  it('returns null for malformed data url', () => {
+    const input = 'data:imagepng;base64,abcd';
+    const res = parseDataUrl(input);
+    assert.strictEqual(res, null);
+  });
+});

--- a/web/src/api/index.js
+++ b/web/src/api/index.js
@@ -10,9 +10,9 @@ const SIMPLE_MIND_MAP_LOCAL_CONFIG = 'SIMPLE_MIND_MAP_LOCAL_CONFIG'
 let mindMapData = null
 
 /**
- * @Author: 王林
- * @Date: 2021-08-02 22:36:48
- * @Desc: 克隆思维导图数据，去除激活状态
+ * Clone mind map tree data and remove active states
+ * @author 王林
+ * @date 2021-08-02 22:36:48
  */
 const copyMindMapTreeData = (tree, root) => {
   if (!root) return null
@@ -28,9 +28,9 @@ const copyMindMapTreeData = (tree, root) => {
 }
 
 /**
- * @Author: 王林
- * @Date: 2021-08-01 10:10:49
- * @Desc: 获取缓存的思维导图数据
+ * Get cached mind map data
+ * @author 王林
+ * @date 2021-08-01 10:10:49
  */
 export const getData = () => {
   if (window.takeOverApp) {
@@ -53,9 +53,9 @@ export const getData = () => {
 }
 
 /**
- * @Author: 王林
- * @Date: 2021-08-01 10:14:28
- * @Desc: 存储思维导图数据
+ * Store mind map data
+ * @author 王林
+ * @date 2021-08-01 10:14:28
  */
 export const storeData = data => {
   try {
@@ -83,9 +83,9 @@ export const storeData = data => {
 }
 
 /**
- * @Author: 王林
- * @Date: 2021-08-01 10:24:56
- * @Desc: 存储思维导图配置数据
+ * Store mind map configuration
+ * @author 王林
+ * @date 2021-08-01 10:24:56
  */
 export const storeConfig = config => {
   try {
@@ -116,10 +116,9 @@ export const storeConfig = config => {
 }
 
 /**
- * javascript comment
- * @Author: 王林
- * @Date: 2022-11-05 14:36:50
- * @Desc: 存储语言
+ * Save selected language
+ * @author 王林
+ * @date 2022-11-05 14:36:50
  */
 export const storeLang = lang => {
   if (window.takeOverApp) {
@@ -130,10 +129,9 @@ export const storeLang = lang => {
 }
 
 /**
- * javascript comment
- * @Author: 王林
- * @Date: 2022-11-05 14:37:36
- * @Desc: 获取存储的语言
+ * Get stored language
+ * @author 王林
+ * @date 2022-11-05 14:37:36
  */
 export const getLang = () => {
   if (window.takeOverApp) {
@@ -148,10 +146,9 @@ export const getLang = () => {
 }
 
 /**
- * javascript comment
- * @Author: 王林25
- * @Date: 2022-11-14 18:57:31
- * @Desc: 存储本地配置
+ * Save local configuration
+ * @author 王林25
+ * @date 2022-11-14 18:57:31
  */
 export const storeLocalConfig = config => {
   if (window.takeOverApp) {
@@ -161,10 +158,9 @@ export const storeLocalConfig = config => {
 }
 
 /**
- * javascript comment
- * @Author: 王林25
- * @Date: 2022-11-14 18:57:37
- * @Desc: 获取本地配置
+ * Get local configuration
+ * @author 王林25
+ * @date 2022-11-14 18:57:37
  */
 export const getLocalConfig = () => {
   if (window.takeOverApp) {

--- a/web/src/lang/zh_cn.js
+++ b/web/src/lang/zh_cn.js
@@ -25,6 +25,7 @@ export default {
     belowLevel2Node: '三级及以下节点',
     nodeBorderType: '节点边框风格',
     nodeUseLineStyle: '是否使用只有底边框的风格',
+    otherConfig: '其他配置',
     associativeLine: '关联线',
     associativeLineWidth: '粗细',
     associativeLineColor: '颜色',


### PR DESCRIPTION
## Summary
- add English README and translation instructions
- translate README in `simple-mind-map`
- translate Chinese comments in `web/src/api/index.js`
- add missing `otherConfig` key in `zh_cn.js`
- fix typo in comment and clarify zoom formula comments
- handle invalid input in `parseDataUrl`
- create unit tests for `parseDataUrl`

## Testing
- `npm run test --prefix simple-mind-map` *(fails: Cannot find package 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685dd2da11808325b3089ce5ff46ebc1