### PR TITLE
Rename fullscreen event helpers

### DIFF
--- a/simple-mind-map/src/plugins/Demonstrate.js
+++ b/simple-mind-map/src/plugins/Demonstrate.js
@@ -1,7 +1,7 @@
 import {
   walk,
   getNodeTreeBoundingRect,
-  fullscrrenEvent,
+  fullscreenEvent,
   fullScreen,
   exitFullScreen,
   formatGetNodeGeneralization
@@ -218,13 +218,13 @@ class Demonstrate {
   // 绑定全屏事件
   bindFullscreenEvent() {
     this.onFullscreenChange = this.onFullscreenChange.bind(this)
-    document.addEventListener(fullscrrenEvent, this.onFullscreenChange)
+    document.addEventListener(fullscreenEvent, this.onFullscreenChange)
   }
 
   // 解绑事件
   unBindEvent() {
     window.removeEventListener('keydown', this.onKeydown)
-    document.removeEventListener(fullscrrenEvent, this.onFullscreenChange)
+    document.removeEventListener(fullscreenEvent, this.onFullscreenChange)
   }
 
   // 全屏状态改变

--- a/simple-mind-map/src/utils/index.js
+++ b/simple-mind-map/src/utils/index.js
@@ -1512,7 +1512,7 @@ export const getNodeListBoundingRect = (
 }
 
 // 全屏事件检测
-const getOnfullscreEnevt = () => {
+const getFullscreenEvent = () => {
   if (document.documentElement.requestFullScreen) {
     return 'fullscreenchange'
   } else if (document.documentElement.webkitRequestFullScreen) {
@@ -1523,7 +1523,7 @@ const getOnfullscreEnevt = () => {
     return 'msfullscreenchange'
   }
 }
-export const fullscrrenEvent = getOnfullscreEnevt()
+export const fullscreenEvent = getFullscreenEvent()
 
 // 全屏
 export const fullScreen = element => {

--- a/web/src/pages/Edit/components/Fullscreen.vue
+++ b/web/src/pages/Edit/components/Fullscreen.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { fullscrrenEvent, fullScreen } from '@/utils'
+import { fullscreenEvent, fullScreen } from '@/utils'
 
 /**
  * @Author: 王林
@@ -41,7 +41,7 @@ export default {
     return {}
   },
   created() {
-    document[fullscrrenEvent] = () => {
+    document[fullscreenEvent] = () => {
       setTimeout(() => {
         this.mindMap.resize()
       }, 1000)

--- a/web/src/utils/index.js
+++ b/web/src/utils/index.js
@@ -3,7 +3,7 @@
  * @Date: 2021-07-11 21:38:09
  * @Desc: 全屏事件检测
  */
-const getOnfullscreEnevt = () => {
+const getFullscreenEvent = () => {
   if (document.documentElement.requestFullScreen) {
     return 'onfullscreenchange'
   } else if (document.documentElement.webkitRequestFullScreen) {
@@ -15,7 +15,7 @@ const getOnfullscreEnevt = () => {
   }
 }
 
-export const fullscrrenEvent = getOnfullscreEnevt()
+export const fullscreenEvent = getFullscreenEvent()
 
 /**
  * @Author: 王林


### PR DESCRIPTION
## Summary
- rename `getOnfullscreEnevt` to `getFullscreenEvent`
- rename `fullscrrenEvent` to `fullscreenEvent`
- update imports and usages

## Testing
- `npm test` *(fails: Cannot find package 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_685de6a14368832598cae7dc19ae074b