### PR TITLE
Fix HTML entity removal bug

### DIFF
--- a/simple-mind-map/src/utils/index.js
+++ b/simple-mind-map/src/utils/index.js
@@ -481,8 +481,8 @@ export const loadImage = imgFile => {
 
 // 移除字符串中的html实体
 export const removeHTMLEntities = str => {
-  ;[['&nbsp;', '&#160;']].forEach(item => {
-    str = str.replaceAll(item[0], item[1])
+  ;['&nbsp;', '&#160;'].forEach(entity => {
+    str = str.replaceAll(entity, ' ')
   })
   return str
 }


### PR DESCRIPTION
## Summary
- sanitize HTML spaces correctly in `removeHTMLEntities`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2d9e5c08325ae619b85943a79df